### PR TITLE
Fix multiple compatibility issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ This is the default config, feel free to change things around (some things like 
         fallback_header = '',
         top_padding = 0,
         bottom_padding = 0,
+        use_git_username_as_author = false,
         author = '',
         branch = 'main',
         gap = ' ',
@@ -97,6 +98,7 @@ This is the default config, feel free to change things around (some things like 
         days = { 'Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat' },
         months = { 'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec' },
         use_current_branch = true,
+        basepoints = { "master", "main" },
         colors = {
           days_and_months_labels = '#7eac6f',
           empty_square_highlight = '#54734a',
@@ -133,7 +135,8 @@ This is the default config, feel free to change things around (some things like 
 ---@field fallback_header string
 ---@field top_padding number
 ---@field bottom_padding number
----@field author string
+---@field use_git_username_as_author boolean
+---@field author string ignored if use_git_username_as_author is true
 ---@field is_horizontal boolean
 ---@field branch string
 ---@field centered boolean
@@ -150,6 +153,7 @@ This is the default config, feel free to change things around (some things like 
 ---@field days string[]
 ---@field months string[]
 ---@field use_current_branch boolean
+---@field basepoints string[] remove commits from base branch, empty array to disable and show all commits
 ---@field colors Colors
 ```
 </details>

--- a/lua/git-dashboard-nvim/config.lua
+++ b/lua/git-dashboard-nvim/config.lua
@@ -11,7 +11,8 @@ Config = {}
 ---@field fallback_header string
 ---@field top_padding number
 ---@field bottom_padding number
----@field author string|nil filter commits base on commit author, empty string disables filter, nil defaults to git config user.name
+---@field use_git_username_as_author boolean
+---@field author string ignored if use_git_username_as_author is true
 ---@field is_horizontal boolean
 ---@field branch string
 ---@field centered boolean
@@ -36,6 +37,7 @@ local defaults = {
   fallback_header = "",
   top_padding = 0,
   bottom_padding = 0,
+  use_git_username_as_author = false,
   author = "",
   branch = "main",
   gap = " ",
@@ -68,7 +70,8 @@ local current_config = defaults
 
 ---@param config table
 Config.set_config_defaults = function(config)
-  return vim.tbl_deep_extend("force", current_config, config)
+  current_config = vim.tbl_deep_extend("force", current_config, config)
+  return current_config
 end
 
 Config.get_config_defaults = function()

--- a/lua/git-dashboard-nvim/config.lua
+++ b/lua/git-dashboard-nvim/config.lua
@@ -11,7 +11,7 @@ Config = {}
 ---@field fallback_header string
 ---@field top_padding number
 ---@field bottom_padding number
----@field author string
+---@field author string|nil filter commits base on commit author, empty string disables filter, nil defaults to git config user.name
 ---@field is_horizontal boolean
 ---@field branch string
 ---@field centered boolean

--- a/lua/git-dashboard-nvim/config.lua
+++ b/lua/git-dashboard-nvim/config.lua
@@ -28,6 +28,7 @@ Config = {}
 ---@field days string[]
 ---@field months string[]
 ---@field use_current_branch boolean
+---@field basepoints string[] remove commits from base branch, empty array to disable and show all commits
 ---@field colors Colors
 
 ---@type Config
@@ -52,6 +53,7 @@ local defaults = {
   days = { "Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat" },
   months = { "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec" },
   use_current_branch = true,
+  basepoints = { "master", "main" },
   colors = {
     days_and_months_labels = "#7eac6f",
     empty_square_highlight = "#54734a",
@@ -61,13 +63,21 @@ local defaults = {
   },
 }
 
+---@type Config
+local current_config = defaults
+
 ---@param config table
 Config.set_config_defaults = function(config)
-  return vim.tbl_deep_extend("force", defaults, config)
+  return vim.tbl_deep_extend("force", current_config, config)
 end
 
 Config.get_config_defaults = function()
   return defaults
+end
+
+---@return Config
+Config.get = function()
+  return current_config
 end
 
 return Config

--- a/lua/git-dashboard-nvim/git.lua
+++ b/lua/git-dashboard-nvim/git.lua
@@ -23,6 +23,14 @@ Git.get_repo_with_owner = function()
   end
 
   return ""
+Git.get_username = function()
+  local handle = io.popen("git config user.name")
+  if not handle then
+    return ""
+  end
+
+  local username = handle:read("*a")
+  return utils.trim(username)
 end
 
 ---@param username string

--- a/lua/git-dashboard-nvim/git.lua
+++ b/lua/git-dashboard-nvim/git.lua
@@ -12,17 +12,21 @@ Git.get_repo_with_owner = function()
   local remote_url = handle:read("*a")
   handle:close()
 
-  if remote_url and remote_url ~= "" then
-    remote_url = remote_url:gsub("%s+", "") -- Remove any trailing newlines or spaces
-
-    local name_with_owner = remote_url:match("github%.com[:/]([^/]+/[^/.]+)%.git")
-      or remote_url:match("github%.com[:/]([^/]+/[^/.]+)")
-    if name_with_owner then
-      return name_with_owner
-    end
+  if not remote_url or remote_url == "" then
+    return ""
   end
 
-  return ""
+  remote_url = remote_url:gsub("%s+", "") -- Remove any trailing newlines or spaces
+
+  return Git._parse_repo_and_owner(remote_url)
+end
+
+Git._parse_repo_and_owner = function(remote_url)
+  return remote_url:match(".*%..*[:/]([^/]+/[^/.]+)")
+    or remote_url:match(".*%..*[:/]([^/]+/[^/.]+).git")
+    or ""
+end
+
 Git.get_username = function()
   local handle = io.popen("git config user.name")
   if not handle then

--- a/lua/git-dashboard-nvim/git.lua
+++ b/lua/git-dashboard-nvim/git.lua
@@ -1,4 +1,5 @@
 local utils = require("git-dashboard-nvim.utils")
+local config = require("git-dashboard-nvim.config")
 
 Git = {}
 
@@ -55,9 +56,8 @@ Git.get_commit_dates = function(username, _branch)
 
   local branch = _branch
 
-  -- should be configurable
-  local basepoints = { "master", "main", "develop" }
-
+  -- cleanup commits by filtering commits from base branch
+  local basepoints = config.get().basepoints
   if not vim.tbl_contains(basepoints, branch) then
     for _, basepoint in ipairs(basepoints) do
       if Git._revision_exists_origin(basepoint) then

--- a/lua/git-dashboard-nvim/heatmap/init.lua
+++ b/lua/git-dashboard-nvim/heatmap/init.lua
@@ -18,7 +18,8 @@ Heatmap.generate_heatmap = function(config)
     return ""
   end
 
-  local commits = Git.get_commit_dates(config.author, config.branch)
+  local username = Git.get_username()
+  local commits = Git.get_commit_dates(config.author or username, config.branch)
 
   if #commits == 0 then
     return ""

--- a/lua/git-dashboard-nvim/heatmap/init.lua
+++ b/lua/git-dashboard-nvim/heatmap/init.lua
@@ -18,8 +18,12 @@ Heatmap.generate_heatmap = function(config)
     return ""
   end
 
-  local username = Git.get_username()
-  local commits = Git.get_commit_dates(config.author or username, config.branch)
+  local author = config.author
+  if config.use_git_username_as_author then
+    author = Git.get_username()
+  end
+
+  local commits = Git.get_commit_dates(author, config.branch)
 
   if #commits == 0 then
     return ""

--- a/lua/git-dashboard-nvim/init.lua
+++ b/lua/git-dashboard-nvim/init.lua
@@ -9,6 +9,13 @@ M = {}
 M.setup = function(config)
   config = config_utils.set_config_defaults(config)
 
+  utils.create_dashboard_update_on_shell_cmd()
+
+  return M.heatmap()
+end
+
+M.heatmap = function()
+  local config = config_utils.get()
   local ascii_heatmap = heatmap.generate_heatmap(config)
 
   if ascii_heatmap == "" then
@@ -18,8 +25,6 @@ M.setup = function(config)
       ascii_heatmap = string.rep("\n", 10)
     end
   end
-
-  utils.create_dashboard_update_on_shell_cmd()
 
   return vim.split(
     string.rep("\n", config.top_padding) .. ascii_heatmap .. string.rep("\n", config.bottom_padding),

--- a/lua/git-dashboard-nvim/utils.lua
+++ b/lua/git-dashboard-nvim/utils.lua
@@ -48,4 +48,8 @@ Utils.current_date_info = function()
   }
 end
 
+Utils.trim = function(str)
+  return str:gsub("^%s+", ""):gsub("%s+$", "")
+end
+
 return Utils

--- a/tests/unit/git_spec.lua
+++ b/tests/unit/git_spec.lua
@@ -19,6 +19,51 @@ describe("git", function()
     assert(repo_with_owner == "juansalvatore/git-dashboard-nvim")
   end)
 
+  it("should parse repo with owner from bitbucket ssh url", function()
+    local git = require("git-dashboard-nvim.git")
+    local repo_with_owner =
+      git._parse_repo_and_owner("git@bitbucket.org:juansalvatore/git-dashboard-nvim.git")
+
+    assert(repo_with_owner ~= nil)
+    assert(repo_with_owner == "juansalvatore/git-dashboard-nvim")
+  end)
+
+  it("should parse repo with owner from github ssh url", function()
+    local git = require("git-dashboard-nvim.git")
+    local repo_with_owner =
+      git._parse_repo_and_owner("git@github.com:juansalvatore/git-dashboard-nvim.git")
+
+    assert(repo_with_owner ~= nil)
+    assert(repo_with_owner == "juansalvatore/git-dashboard-nvim")
+  end)
+
+  it("should parse repo with owner from github ssh url without .git", function()
+    local git = require("git-dashboard-nvim.git")
+    local repo_with_owner =
+      git._parse_repo_and_owner("git@github.com:juansalvatore/git-dashboard-nvim")
+
+    assert(repo_with_owner ~= nil)
+    assert(repo_with_owner == "juansalvatore/git-dashboard-nvim")
+  end)
+
+  it("should parse repo with owner from github https url", function()
+    local git = require("git-dashboard-nvim.git")
+    local repo_with_owner =
+      git._parse_repo_and_owner("https://github.com/juansalvatore/git-dashboard-nvim.git")
+
+    assert(repo_with_owner ~= nil)
+    assert(repo_with_owner == "juansalvatore/git-dashboard-nvim")
+  end)
+
+  it("should parse repo with owner from github https url without .git", function()
+    local git = require("git-dashboard-nvim.git")
+    local repo_with_owner =
+      git._parse_repo_and_owner("https://github.com/juansalvatore/git-dashboard-nvim")
+
+    assert(repo_with_owner ~= nil)
+    assert(repo_with_owner == "juansalvatore/git-dashboard-nvim")
+  end)
+
   it("should return commit dates", function()
     local git = require("git-dashboard-nvim.git")
     local commits = git.get_commit_dates("username", "main")

--- a/tests/unit/git_spec.lua
+++ b/tests/unit/git_spec.lua
@@ -19,49 +19,67 @@ describe("git", function()
     assert(repo_with_owner == "juansalvatore/git-dashboard-nvim")
   end)
 
-  it("should parse repo with owner from bitbucket ssh url", function()
-    local git = require("git-dashboard-nvim.git")
-    local repo_with_owner =
-      git._parse_repo_and_owner("git@bitbucket.org:juansalvatore/git-dashboard-nvim.git")
+  describe("_parse_repo_and_owner", function()
+    it("should parse repo with owner from bitbucket ssh url", function()
+      local git = require("git-dashboard-nvim.git")
+      local repo_with_owner =
+        git._parse_repo_and_owner("git@bitbucket.org:juansalvatore/git-dashboard-nvim.git")
 
-    assert(repo_with_owner ~= nil)
-    assert(repo_with_owner == "juansalvatore/git-dashboard-nvim")
+      assert(repo_with_owner ~= nil)
+      assert(repo_with_owner == "juansalvatore/git-dashboard-nvim")
+    end)
+
+    it("should parse repo with owner from github ssh url", function()
+      local git = require("git-dashboard-nvim.git")
+      local repo_with_owner =
+        git._parse_repo_and_owner("git@github.com:juansalvatore/git-dashboard-nvim.git")
+
+      assert(repo_with_owner ~= nil)
+      assert(repo_with_owner == "juansalvatore/git-dashboard-nvim")
+    end)
+
+    it("should parse repo with owner from github ssh url without .git", function()
+      local git = require("git-dashboard-nvim.git")
+      local repo_with_owner =
+        git._parse_repo_and_owner("git@github.com:juansalvatore/git-dashboard-nvim")
+
+      assert(repo_with_owner ~= nil)
+      assert(repo_with_owner == "juansalvatore/git-dashboard-nvim")
+    end)
+
+    it("should parse repo with owner from github https url", function()
+      local git = require("git-dashboard-nvim.git")
+      local repo_with_owner =
+        git._parse_repo_and_owner("https://github.com/juansalvatore/git-dashboard-nvim.git")
+
+      assert(repo_with_owner ~= nil)
+      assert(repo_with_owner == "juansalvatore/git-dashboard-nvim")
+    end)
+
+    it("should parse repo with owner from github https url without .git", function()
+      local git = require("git-dashboard-nvim.git")
+      local repo_with_owner =
+        git._parse_repo_and_owner("https://github.com/juansalvatore/git-dashboard-nvim")
+
+      assert(repo_with_owner ~= nil)
+      assert(repo_with_owner == "juansalvatore/git-dashboard-nvim")
+    end)
   end)
 
-  it("should parse repo with owner from github ssh url", function()
-    local git = require("git-dashboard-nvim.git")
-    local repo_with_owner =
-      git._parse_repo_and_owner("git@github.com:juansalvatore/git-dashboard-nvim.git")
+  describe("_revision_exists_origin", function()
+    it("should return true for existing ref", function()
+      local git = require("git-dashboard-nvim.git")
+      local result = git._revision_exists_origin("main")
 
-    assert(repo_with_owner ~= nil)
-    assert(repo_with_owner == "juansalvatore/git-dashboard-nvim")
-  end)
+      assert(result)
+    end)
 
-  it("should parse repo with owner from github ssh url without .git", function()
-    local git = require("git-dashboard-nvim.git")
-    local repo_with_owner =
-      git._parse_repo_and_owner("git@github.com:juansalvatore/git-dashboard-nvim")
+    it("should return false for non-existing ref", function()
+      local git = require("git-dashboard-nvim.git")
+      local result = git._revision_exists_origin("master")
 
-    assert(repo_with_owner ~= nil)
-    assert(repo_with_owner == "juansalvatore/git-dashboard-nvim")
-  end)
-
-  it("should parse repo with owner from github https url", function()
-    local git = require("git-dashboard-nvim.git")
-    local repo_with_owner =
-      git._parse_repo_and_owner("https://github.com/juansalvatore/git-dashboard-nvim.git")
-
-    assert(repo_with_owner ~= nil)
-    assert(repo_with_owner == "juansalvatore/git-dashboard-nvim")
-  end)
-
-  it("should parse repo with owner from github https url without .git", function()
-    local git = require("git-dashboard-nvim.git")
-    local repo_with_owner =
-      git._parse_repo_and_owner("https://github.com/juansalvatore/git-dashboard-nvim")
-
-    assert(repo_with_owner ~= nil)
-    assert(repo_with_owner == "juansalvatore/git-dashboard-nvim")
+      assert(not result)
+    end)
   end)
 
   it("should return commit dates", function()


### PR DESCRIPTION
I created multiple branches on my fork, but was annoying to open separate PRs for it.
It's still in different commits.

* Add support for remote url different than github (such as bitbucket)
* Use the username from git config to fetch commits
* Remove the `--not origin/main`, not sure why it was introduced, but plugin would crash on remotes that do not have a `main` branch (e.g. that still use `master`)