### PR TITLE
feat: `setup` can be called without arguments

### DIFF
--- a/lua/git-dashboard-nvim/init.lua
+++ b/lua/git-dashboard-nvim/init.lua
@@ -4,10 +4,10 @@ local config_utils = require("git-dashboard-nvim.config")
 
 M = {}
 
----@param config Config
+---@param config? Config
 ---@return string[]
 M.setup = function(config)
-  config = config_utils.set_config_defaults(config)
+  config = config_utils.set_config_defaults(config or {})
 
   local ascii_heatmap = heatmap.generate_heatmap(config)
 


### PR DESCRIPTION
Just a convenience change. Users can now call the `setup` function without arguments if they want to use the default config. 