### PR TITLE
Extends support for alpha-nvim

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ I may add breaking changes to improve the config in the future.
 
 ## ⇁ Intro
 `git-dashboard-nvim` is a modular solution to display your git commit contributions as an nvim heatmap dashboard that adapts to the current branch and repository.
-It uses [vimdev/dashboard-nvim](https://github.com/nvimdev/dashboard-nvim) as the base for the dashboard and this plugin generates the header dynamically that we can pass to dashboard-nvim. 
+It uses [vimdev/dashboard-nvim](https://github.com/nvimdev/dashboard-nvim) or [goolord/alpha-nvim](https://github.com/goolord/alpha-nvim) as the base for the dashboard and this plugin generates the header dynamically that we can pass to dashboard-nvim or alpha-nvim. 
 It allows you to track project based progress in a visual way, making your nvim dashboard look cool while still being useful by showcasing the current git branch and project.
 I've mainly developed this plugin for myself, so to make sure it looks well for you, check the [Style Variations](#-Style-Variations) section, to see some fun styling configurations.
 
@@ -34,7 +34,7 @@ I've mainly developed this plugin for myself, so to make sure it looks well for 
 * neovim 0.8.0+ required
 * install using your favorite plugin manager (i am using `Lazy` in this case)
 * install using [lazy.nvim](https://github.com/folke/lazy.nvim)
-* Install [nvimdev/dashboard-nvim](https://github.com/nvimdev/dashboard-nvim)
+* Install [nvimdev/dashboard-nvim](https://github.com/nvimdev/dashboard-nvim) or [goolord/alpha-nvim](https://github.com/goolord/alpha-nvim)
   
 ```lua
 {

--- a/lua/git-dashboard-nvim/heatmap/utils.lua
+++ b/lua/git-dashboard-nvim/heatmap/utils.lua
@@ -72,7 +72,7 @@ HeatmapUtils.generate_ascii_heatmap = function(
 
   -- add highlights to the heatmap based on the config settings
   vim.api.nvim_create_autocmd("FileType", {
-    pattern = "dashboard",
+    pattern = { "dashboard", "alpha" },
     callback = function()
       Highlights.add_highlights(config, current_date_info, branch_label, title)
 


### PR DESCRIPTION
Adds base support for [alpha-nvim](https://github.com/goolord/alpha-nvim)
A future improvement can be addding logic to center the title and branch horizontally without relying on dashboard-nvim.

Config:
```lua
  {
    'goolord/alpha-nvim',
    dependencies = {
      'nvim-tree/nvim-web-devicons',
      'nvim-lua/plenary.nvim',
      { 'juansalvatore/git-dashboard-nvim', dependencies = { 'nvim-lua/plenary.nvim' } },
    },
    config = function()
      local dashboard = require 'alpha.themes.dashboard'

      local git_dashboard = require('git-dashboard-nvim').setup {}

      dashboard.section.header.val = git_dashboard
      dashboard.section.buttons.val = {}

      require('alpha').setup(dashboard.opts)
    end,
  }
```
<img width="1728" alt="image" src="https://github.com/juansalvatore/git-dashboard-nvim/assets/11010928/27d527bc-d9e0-403c-a1de-271f849b4e3c">
