### PR TITLE
fix(git): handle non-unix stderr redirection

### DIFF
--- a/lua/git-dashboard-nvim/git.lua
+++ b/lua/git-dashboard-nvim/git.lua
@@ -1,11 +1,13 @@
 local utils = require("git-dashboard-nvim.utils")
 local config = require("git-dashboard-nvim.config")
+local is_windows = vim.fn.has("win32")
+local null = is_windows and "NUL" or "/dev/null"
 
 Git = {}
 
 ---@return string
 Git.get_repo_with_owner = function()
-  local handle = io.popen("git remote get-url origin 2>/dev/null")
+  local handle = io.popen("git remote get-url origin 2>" .. null)
   if not handle then
     return ""
   end
@@ -95,7 +97,7 @@ end
 
 ---@return string
 Git.get_current_branch = function()
-  local handle = io.popen("git branch --show-current 2>/dev/null")
+  local handle = io.popen("git branch --show-current 2>" .. null)
   if not handle then
     return ""
   end


### PR DESCRIPTION
This PR is specifically for the Windows crowd. 

![ArrestedDevelopmentDavidCrossGIF](https://github.com/juansalvatore/git-dashboard-nvim/assets/39483124/48aa8c35-2ede-43b3-bb02-b8b96aadd3c7)

I tried running this plugin on my Windows machine and was getting a blank ASCII. After some head-scratching, I was able to determine this was due to the Unix-style stderr redirection on a couple of the functions in the `git.lua` file.

I've fixed this by adding two new local variables and using the built-in `vim.fn.has` API to determine the correct output.
