### PR TITLE
Fix: Constrain highlights to DashboardHeader section and remove BufLeave clean event

### DIFF
--- a/lua/git-dashboard-nvim/heatmap/utils.lua
+++ b/lua/git-dashboard-nvim/heatmap/utils.lua
@@ -70,20 +70,6 @@ HeatmapUtils.generate_ascii_heatmap = function(
     ascii_heatmap = ascii_heatmap .. "\n\n"
   end
 
-  -- add highlights to the heatmap based on the config settings
-  vim.api.nvim_create_autocmd("FileType", {
-    pattern = { "dashboard", "alpha" },
-    callback = function()
-      Highlights.add_highlights(config, current_date_info, branch_label, title)
-
-      -- hide cursor
-      if config.hide_cursor == true then
-        vim.api.nvim_command("hi Cursor blend=100")
-        vim.api.nvim_command("set guicursor+=a:Cursor/lCursor")
-      end
-    end,
-  })
-
   -- horizontal heatmap
   if config.is_horizontal then
     -- add month labels
@@ -203,6 +189,30 @@ HeatmapUtils.generate_ascii_heatmap = function(
     local padding = math.floor((lines - ascii_heatmap_lines_count) / 2)
     ascii_heatmap = string.rep("\n", padding) .. ascii_heatmap
   end
+
+  -- add highlights to the heatmap based on the config settings
+  vim.api.nvim_create_autocmd("FileType", {
+    pattern = { "dashboard", "alpha" },
+    callback = function()
+      local start_line = 1
+      local end_line = #vim.split(ascii_heatmap, "\n")
+
+      Highlights.add_highlights(
+        config,
+        current_date_info,
+        branch_label,
+        title,
+        start_line,
+        end_line
+      )
+
+      -- hide cursor
+      if config.hide_cursor == true then
+        vim.api.nvim_command("hi Cursor blend=100")
+        vim.api.nvim_command("set guicursor+=a:Cursor/lCursor")
+      end
+    end,
+  })
 
   return ascii_heatmap
 end

--- a/lua/git-dashboard-nvim/heatmap/utils.lua
+++ b/lua/git-dashboard-nvim/heatmap/utils.lua
@@ -194,17 +194,7 @@ HeatmapUtils.generate_ascii_heatmap = function(
   vim.api.nvim_create_autocmd("FileType", {
     pattern = { "dashboard", "alpha" },
     callback = function()
-      local start_line = 1
-      local end_line = #vim.split(ascii_heatmap, "\n")
-
-      Highlights.add_highlights(
-        config,
-        current_date_info,
-        branch_label,
-        title,
-        start_line,
-        end_line
-      )
+      Highlights.add_highlights(config, current_date_info, branch_label, title)
 
       -- hide cursor
       if config.hide_cursor == true then

--- a/lua/git-dashboard-nvim/highlights/init.lua
+++ b/lua/git-dashboard-nvim/highlights/init.lua
@@ -9,10 +9,7 @@ Highlights._add_highlight_group = function(group_name, match, fg_color)
   -- Ensure proper escaping of special characters in `match`
   local pattern = vim.fn.escape(match, "/")
 
-  -- Debug print to verify `pattern` before using it
-  print("Pattern:", pattern)
-
-  -- Construct the syntax match command
+  -- Construct the syntax match command, using containedin ensures that the match is only applied to the DashboardHeader section
   local cmd = string.format("syntax match %s /%s/ containedin=DashboardHeader", group_name, pattern)
   vim.cmd(cmd)
 end

--- a/lua/git-dashboard-nvim/highlights/init.lua
+++ b/lua/git-dashboard-nvim/highlights/init.lua
@@ -57,7 +57,12 @@ Highlights.add_highlights = function(config, current_date_info, branch_label, ti
   end
 
   -- add highlight to match any number
-  vim.cmd("call matchadd('DashboardHeaderMonth', '\\d\\+')")
+  -- vim.cmd("call matchadd('DashboardHeaderMonth', '\\d\\+')")
+  Highlights._add_highlight_group(
+    "DashboardHeaderMonth",
+    "\\d\\+",
+    config.colors.days_and_months_labels
+  )
 
   Highlights._add_highlight_group("DashboardHeaderTitle", title, config.colors.dashboard_title)
 
@@ -67,11 +72,11 @@ Highlights.add_highlights = function(config, current_date_info, branch_label, ti
     config.colors.branch_highlight
   )
 
-  vim.cmd.autocmd(
-    "BufLeave",
-    "*",
-    "highlight clear DashboardHeaderEmptySquare | highlight clear DashboardHeaderDay | highlight clear DashboardHeaderMonth | highlight clear DashboardHeaderFilledSquare | highlight clear DashboardHeaderTitle | highlight clear DashboardHeaderBranch"
-  )
+  -- vim.cmd.autocmd(
+  --   "BufLeave",
+  --   "*",
+  --   "highlight clear DashboardHeaderEmptySquare | highlight clear DashboardHeaderDay | highlight clear DashboardHeaderMonth | highlight clear DashboardHeaderFilledSquare | highlight clear DashboardHeaderTitle | highlight clear DashboardHeaderBranch"
+  -- )
   -- set cursor color to white when leaving the buffer
   vim.cmd.autocmd("BufLeave", "*", "highlight Cursor blend=0")
   vim.cmd.autocmd("BufLeave", "*", "set guicursor+=a:Cursor/lCursor")

--- a/lua/git-dashboard-nvim/highlights/init.lua
+++ b/lua/git-dashboard-nvim/highlights/init.lua
@@ -5,7 +5,16 @@ Highlights = {}
 ---@param fg_color string
 Highlights._add_highlight_group = function(group_name, match, fg_color)
   vim.cmd("highlight " .. group_name .. " guifg=" .. fg_color)
-  vim.cmd('call matchadd("' .. group_name .. '", "' .. match .. '")')
+
+  -- Ensure proper escaping of special characters in `match`
+  local pattern = vim.fn.escape(match, "/")
+
+  -- Debug print to verify `pattern` before using it
+  print("Pattern:", pattern)
+
+  -- Construct the syntax match command
+  local cmd = string.format("syntax match %s /%s/ containedin=DashboardHeader", group_name, pattern)
+  vim.cmd(cmd)
 end
 
 ---@param config Config
@@ -60,6 +69,7 @@ Highlights.add_highlights = function(config, current_date_info, branch_label, ti
     branch_label,
     config.colors.branch_highlight
   )
+
   vim.cmd.autocmd(
     "BufLeave",
     "*",

--- a/lua/git-dashboard-nvim/highlights/init.lua
+++ b/lua/git-dashboard-nvim/highlights/init.lua
@@ -1,3 +1,14 @@
+--[[
+
+Sets the highlights for the dashboard header section
+Highlights will only be applied to the DashboardHeader section of the buffer
+For for dashboard.nvim the containedin option works well, but for alpha.nvim 
+it doesn't prevent the highlights from being applied to the entire buffer
+so we added temporary whitespace to the beginning of the match to prevent 
+easily matching other sections of the buffer
+
+]]
+
 Highlights = {}
 
 ---@param group_name string
@@ -34,8 +45,8 @@ Highlights.add_highlights = function(config, current_date_info, branch_label, ti
 
   for i = 1, #config.days do
     Highlights._add_highlight_group(
-      "DashboardHeaderDay",
-      config.days[i]:sub(1, 3),
+      "DashboardHeaderDay" .. i,
+      "   " .. config.days[i]:sub(1, 3) .. config.day_label_gap,
       config.colors.days_and_months_labels
     )
   end
@@ -43,7 +54,7 @@ Highlights.add_highlights = function(config, current_date_info, branch_label, ti
   for i = 1, current_date_info.current_month do
     Highlights._add_highlight_group(
       "DashboardHeaderMonth",
-      config.months[i]:sub(1, 3),
+      config.months[i]:sub(1, 3) .. " ",
       config.colors.days_and_months_labels
     )
   end
@@ -68,15 +79,10 @@ Highlights.add_highlights = function(config, current_date_info, branch_label, ti
 
   Highlights._add_highlight_group(
     "DashboardHeaderBranch",
-    branch_label,
+    "   " .. branch_label,
     config.colors.branch_highlight
   )
 
-  -- vim.cmd.autocmd(
-  --   "BufLeave",
-  --   "*",
-  --   "highlight clear DashboardHeaderEmptySquare | highlight clear DashboardHeaderDay | highlight clear DashboardHeaderMonth | highlight clear DashboardHeaderFilledSquare | highlight clear DashboardHeaderTitle | highlight clear DashboardHeaderBranch"
-  -- )
   -- set cursor color to white when leaving the buffer
   vim.cmd.autocmd("BufLeave", "*", "highlight Cursor blend=0")
   vim.cmd.autocmd("BufLeave", "*", "set guicursor+=a:Cursor/lCursor")

--- a/tests/unit/config_spec.lua
+++ b/tests/unit/config_spec.lua
@@ -59,6 +59,8 @@ describe("config", function()
         branch_highlight = "#8DC07C",
         dashboard_title = "#a3cc96",
       },
+      basepoints = { "master", "main" },
+      use_git_username_as_author = false,
     })
   end)
 
@@ -145,6 +147,8 @@ describe("config", function()
         branch_highlight = "#8DC07C",
         dashboard_title = "#a3cc96",
       },
+      basepoints = { "master", "main" },
+      use_git_username_as_author = false,
     })
   end)
 end)


### PR DESCRIPTION
Additions:

- Fixes the highlights for dashboard.nvim adding `containedin=DashboardHeader` to fix highlights applying to other parts of the buffer.
- This allows to remove the BufLeave used to clear highlights that caused the dashboard colors to disappear when opening other buffers like telescope/quickfix lists/ running Lazy, etc. Now we only rely on the above.
- Finally, it fixes some tests broken in main that broke from a previous contribution https://github.com/juansalvatore/git-dashboard-nvim/pull/1

<img width="1728" alt="Screenshot 2024-06-28 at 12 58 57 AM" src="https://github.com/juansalvatore/git-dashboard-nvim/assets/11010928/1abdbce5-ea9c-40f3-bf73-f6c6350643a6">
config:

```lua

  {
    'goolord/alpha-nvim',
    enabled = true,
    dependencies = {
      { dir = '~/personal/plugins/git-dashboard-nvim', dependencies = { 'nvim-lua/plenary.nvim' } },
      'nvim-tree/nvim-web-devicons',
      'nvim-lua/plenary.nvim',
    },
    event = 'VimEnter',
    config = function()
      local alpha = require 'alpha'
      local default_dashboard = {
        [[                                                     ]],
        [[ ███╗   ██╗███████╗ ██████╗ ██╗   ██╗██╗███╗   ███╗  ]],
        [[ ████╗  ██║██╔════╝██╔═══██╗██║   ██║██║████╗ ████║  ]],
        [[ ██╔██╗ ██║█████╗  ██║   ██║██║   ██║██║██╔████╔██║  ]],
        [[ ██║╚██╗██║██╔══╝  ██║   ██║╚██╗ ██╔╝██║██║╚██╔╝██║  ]],
        [[ ██║ ╚████║███████╗╚██████╔╝ ╚████╔╝ ██║██║ ╚═╝ ██║  ]],
      }

      --- @diagnostic disable-next-line:missing-fields
      local git_dashboard = require('git-dashboard-nvim').setup {
        centered = false,
        top_padding = 0,
        bottom_padding = 0,
        show_current_branch = false,
        hide_cursor = true,
        fallback_header = vim.fn.join(default_dashboard, '\n'),
        title = 'owner_with_repo_name',
        days = { 's', 'm', 't', 'w', 't', 'f', 's' },
        colors = {
          --catpuccin theme
          days_and_months_labels = '#8FBCBB',
          empty_square_highlight = '#3B4252',
          filled_square_highlights = {
            '#88C0D0',
            '#88C0D0',
            '#88C0D0',
            '#88C0D0',
            '#88C0D0',
            '#88C0D0',
            '#88C0D0',
          },
          branch_highlight = '#88C0D0',
          dashboard_title = '#88C0D0',
        },
      }

      local dashboard = require 'alpha.themes.dashboard'
      local theta = require 'alpha.themes.theta'

      theta.header.opts.hl = 'DashboardHeader'
      theta.header.val = git_dashboard

      theta.buttons.val = {
        {
          type = 'text',
          val = 'Quick links',
          opts = { hl = 'SpecialComment', position = 'center' },
        },
        { type = 'padding', val = 1 },
        dashboard.button('e', '󰈔  New file', '<Cmd>ene<CR>'),
        dashboard.button('Ctrl p', '󰈞  Find file'),
        dashboard.button('Ctrl h', '󰈏  Old files'),
        dashboard.button('Ctrl f', '󰊄  Live grep'),
        dashboard.button('l', '󰇯  Leetcode', '<Cmd>Leet<CR>'),
        dashboard.button('c', '  Configuration', '<Cmd>edit ~/.config/nvim/init.lua<CR>'),
        dashboard.button('d', '  Database', '<Cmd>DBUIToggle<CR>'),
        dashboard.button('q', '󰅚  Quit', '<Cmd>qa<CR>'),
      }

      alpha.setup(theta.config)
    end,
  },
```
<img width="1728" alt="Screenshot 2024-06-28 at 12 59 32 AM" src="https://github.com/juansalvatore/git-dashboard-nvim/assets/11010928/1bb1de74-e06f-4dba-a314-d65f1cbeeea2">

```lua
      local git_dashboard = require('git-dashboard-nvim').setup {
        days = { 's', 'm', 't', 'w', 't', 'f', 's' },
        basepoints = {},
      }

      local opts = {
        theme = 'doom',
        config = {
          header = git_dashboard,
          center = {
            -- { action = '', desc = '', icon = '', key = 'n' },
            { action = 'ene | startinsert', desc = ' New File', icon = ' ', key = 'n' },
            { action = 'Telescope oldfiles', desc = ' Recent Files', icon = ' ', key = 'r' },
            { action = 'Telescope live_grep', desc = ' Find Text', icon = ' ', key = 'g' },
            { action = 'Lazy', desc = ' Lazy', icon = '󰒲 ', key = 'l' },
            { action = 'qa', desc = ' Quit', icon = ' ', key = 'q' },
          },
          footer = function()
            return {}
          end,
        },
      }
```
Related issue: https://github.com/juansalvatore/git-dashboard-nvim/issues/5