### PR TITLE
Ensure dashboard displays even when there's no remote_url

### DIFF
--- a/lua/git-dashboard-nvim/git.lua
+++ b/lua/git-dashboard-nvim/git.lua
@@ -27,7 +27,7 @@ end
 
 Git._parse_repo_and_owner = function(remote_url)
   return remote_url:match(".*%..*[:/]([^/]+/[^/.]+)")
-    or remote_url:match(".*%..*[:/]([^/]+/[^/.]+).git")
+    or remote_url:match(".*%..*[:/]([^/]+/[^/]+).git")
     or ""
 end
 

--- a/lua/git-dashboard-nvim/git.lua
+++ b/lua/git-dashboard-nvim/git.lua
@@ -26,7 +26,9 @@ Git.get_repo_with_owner = function()
 end
 
 Git._parse_repo_and_owner = function(remote_url)
-  return remote_url:match(".*%..*[:/]([^/]+/[^/]+).git") or ""
+  return remote_url:match(".*%..*[:/]([^/]+/[^/]+).git")
+    or remote_url:match(".*%..*[:/]([^/]+/[^/.]+)")
+    or ""
 end
 
 Git.get_username = function()

--- a/lua/git-dashboard-nvim/git.lua
+++ b/lua/git-dashboard-nvim/git.lua
@@ -26,9 +26,7 @@ Git.get_repo_with_owner = function()
 end
 
 Git._parse_repo_and_owner = function(remote_url)
-  return remote_url:match(".*%..*[:/]([^/]+/[^/.]+)")
-    or remote_url:match(".*%..*[:/]([^/]+/[^/]+).git")
-    or ""
+  return remote_url:match(".*%..*[:/]([^/]+/[^/]+).git") or ""
 end
 
 Git.get_username = function()

--- a/lua/git-dashboard-nvim/heatmap/init.lua
+++ b/lua/git-dashboard-nvim/heatmap/init.lua
@@ -25,10 +25,6 @@ Heatmap.generate_heatmap = function(config)
 
   local commits = Git.get_commit_dates(author, config.branch)
 
-  if #commits == 0 then
-    return ""
-  end
-
   local current_date_info = utils.current_date_info()
 
   local base_heatmap = HeatmapUtils.generate_base_heatmap(commits, current_date_info)

--- a/lua/git-dashboard-nvim/heatmap/init.lua
+++ b/lua/git-dashboard-nvim/heatmap/init.lua
@@ -15,7 +15,7 @@ Heatmap.generate_heatmap = function(config)
   local repo_with_owner = Git.get_repo_with_owner() -- owner/repo
 
   if repo_with_owner == "" or not repo_with_owner then
-    return ""
+    repo_with_owner = vim.fn.getcwd()
   end
 
   local author = config.author

--- a/lua/git-dashboard-nvim/heatmap/utils.lua
+++ b/lua/git-dashboard-nvim/heatmap/utils.lua
@@ -183,7 +183,7 @@ HeatmapUtils.generate_ascii_heatmap = function(
 
   -- center vertically ascii heatmap
   if config.centered then
-    local lines = vim.api.nvim_get_option("lines")
+    local lines = vim.api.nvim_get_option_value("lines", {})
     local ascii_heatmap_lines = vim.split(ascii_heatmap, "\n")
     local ascii_heatmap_lines_count = #ascii_heatmap_lines
     local padding = math.floor((lines - ascii_heatmap_lines_count) / 2)

--- a/tests/unit/git_spec.lua
+++ b/tests/unit/git_spec.lua
@@ -38,6 +38,22 @@ describe("git", function()
       assert(repo_with_owner == "juansalvatore/git-dashboard-nvim")
     end)
 
+    it("should parse repo with extra dot in name", function()
+      local git = require("git-dashboard-nvim.git")
+      local repo_with_owner = git._parse_repo_and_owner("git@github.com:csessh/.dotfiles.git")
+
+      assert(repo_with_owner ~= nil)
+      assert(repo_with_owner == "csessh/.dotfiles")
+    end)
+
+    it("should parse repo with extra dot in name", function()
+      local git = require("git-dashboard-nvim.git")
+      local repo_with_owner = git._parse_repo_and_owner("git@github.com:csessh/test.nvim.git")
+
+      assert(repo_with_owner ~= nil)
+      assert(repo_with_owner == "csessh/test.nvim")
+    end)
+
     it("should parse repo with owner from github ssh url without .git", function()
       local git = require("git-dashboard-nvim.git")
       local repo_with_owner =


### PR DESCRIPTION
closes #9 

Rather than falling back to a blank dashboard when remote_url cannot be extracted due to:
- no remote -> no `origin` 
- remotes are named something else but `origin` 

This plugin shouldn't depend on a remote to work when all git history is available locally. 

Here are some test cases: 
Given the following config:

```lua
---@diagnostic disable: missing-fields
return {
    {
        dir = "~/Documents/nvim-plugins/git-dashboard-nvim",
        dev = true,
        dependencies = { "nvim-lua/plenary.nvim" },
    },
    {
        "nvimdev/dashboard-nvim",
        event = "VimEnter",
        opts = function()
            local header = require("git-dashboard-nvim").setup {
                title = "owner_with_repo_name",
            }

            return {
                theme = "doom",
                config = {
                    header = header,
                    center = {
                        { action = "", desc = "", icon = "", key = "n" },
                    },
                    footer = function()
                        return {}
                    end,
                },
            }
        end,
    },
}
```

```bash
fw13 :: Documents/nvim-plugins/git-dashboard-nvim ‹feat-remote› » git remote -v
origin	git@github.com:csessh/git-dashboard-nvim.git (fetch)
origin	git@github.com:csessh/git-dashboard-nvim.git (push)
tdo	git@github.com:csessh/git-dashboard-nvim.git (fetch)
tdo	git@github.com:csessh/git-dashboard-nvim.git (push)
```

**Result**: dashboard works, `<owner>/<repo name>` extracted ok
![Screenshot from 2024-10-22 22-26-11](https://github.com/user-attachments/assets/2972e55b-0f3b-460e-8084-3171ef3dcc65)


```bash
fw13 :: ~/.dotfiles ‹main*› » git remote -v
origin	git@github.com:csessh/.dotfiles.git (fetch)
origin	git@github.com:csessh/.dotfiles.git (push)
```

**Result**: dashboard works , `<owner>/<repo name>` extracted ok
![Uploading Screenshot from 2024-10-22 22-28-28.png…]()

```bash
fw13 :: ~/Documents/Obsidian ‹main› » git remote -v
fw13 :: ~/Documents/Obsidian ‹main› » 
```

**Result**: without remote url, current directory is used to display instead
![Screenshot from 2024-10-22 22-29-52](https://github.com/user-attachments/assets/a1ba087c-ce99-428a-9ab1-5e0c2965804f)


```bash
fw13 :: Documents/nvim-plugins/stopinsert.nvim ‹main› » git remote -v               
origin	git@github.com:csessh/stopinsert.nvim.git (fetch)
origin	git@github.com:csessh/stopinsert.nvim.git (push)
```

**Result**: dashboard works, `<owner>/<repo name>` extracted ok
![Screenshot from 2024-10-22 22-38-26](https://github.com/user-attachments/assets/ca69e91a-1342-432b-94d0-37a154e138ad)

