### PR TITLE
bug: return nil value when current dir isn't a git repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,4 @@ doc/tags
 Session.vim
 .DS_Store
 NUL
-
+.editorconfig

--- a/lua/git-dashboard-nvim/git.lua
+++ b/lua/git-dashboard-nvim/git.lua
@@ -6,6 +6,22 @@ local null = is_windows and "NUL" or "/dev/null"
 
 Git = {}
 
+---@return boolean
+Git.is_git_repo = function()
+  local handle = io.popen("git status &>" .. null .. "; echo $?")
+  if not handle then
+    return false
+  end
+
+  local exit_code = handle:read("*a")
+  handle:close()
+
+  -- git status command returns 
+  -- 0 exit code if it is a git repository,
+  -- 128 exit code otherwise
+  return tonumber(exit_code) == 0
+end
+
 ---@return string
 Git.get_repo_with_owner = function()
   local handle = io.popen("git remote get-url origin 2>" .. null)

--- a/lua/git-dashboard-nvim/heatmap/init.lua
+++ b/lua/git-dashboard-nvim/heatmap/init.lua
@@ -7,6 +7,10 @@ Heatmap = {}
 ---@param config Config
 ---@return string
 Heatmap.generate_heatmap = function(config)
+  if not Git.is_git_repo() then
+    return ""
+  end
+
   if config.use_current_branch then
     config.branch = Git.get_current_branch()
   end
@@ -24,13 +28,20 @@ Heatmap.generate_heatmap = function(config)
   end
 
   local commits = Git.get_commit_dates(author, config.branch)
-
   local current_date_info = utils.current_date_info()
 
-  local base_heatmap = HeatmapUtils.generate_base_heatmap(commits, current_date_info)
+  local base_heatmap = HeatmapUtils.generate_base_heatmap(
+    commits,
+    current_date_info
+  )
 
-  local ascii_heatmap =
-    HeatmapUtils.generate_ascii_heatmap(base_heatmap, config, repo_with_owner, current_date_info)
+  local ascii_heatmap = HeatmapUtils.generate_ascii_heatmap(
+    base_heatmap,
+    config,
+    repo_with_owner,
+    current_date_info
+  )
+
   return ascii_heatmap
 end
 

--- a/tests/unit/git_spec.lua
+++ b/tests/unit/git_spec.lua
@@ -104,4 +104,11 @@ describe("git", function()
 
     assert(commits ~= nil)
   end)
+
+  it("should return git status exit code 0", function()
+    local git = require("git-dashboard-nvim.git")
+    local is_git_repo = git.is_git_repo()
+
+    assert(is_git_repo == true)
+  end)
 end)


### PR DESCRIPTION
closes #11 

I added an initial check for git repo using `git status &>/dev/null; echo $?`. 

Here's some test cases: 

Not a git repo:
![Screenshot From 2024-11-10 10-43-35](https://github.com/user-attachments/assets/7fe9babb-07ca-421d-a9ea-fdad40e8230c)

Standard git repo with commits:
![Screenshot From 2024-11-10 10-43-44](https://github.com/user-attachments/assets/9eac97e2-4c4e-4959-8092-038a390211a2)

Standard git repo with no commit:
![Screenshot From 2024-11-10 10-43-52](https://github.com/user-attachments/assets/dc3e69f4-5932-4520-b40a-ba401483b7d7)

